### PR TITLE
Added `trunc`, and fixed docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ function(Fraction) {
 
 Using Fraction.js with TypeScript
 ===
-```js
+```typescript
 import Fraction from "fraction.js";
 console.log(Fraction("123/456"));
 ```

--- a/bigfraction.js
+++ b/bigfraction.js
@@ -370,6 +370,10 @@
     }
   }
 
+  function trunc(x) {
+    return typeof x === 'bigint' ? x : x - x % 1;
+  }
+
   /**
    * Module constructor
    *
@@ -739,10 +743,6 @@
       let N = this["n"];
       let D = this["d"];
 
-      function trunc(x) {
-          return typeof x === 'bigint' ? x : Math.floor(x);
-      }
-
       dec = dec || 15; // 15 = decimal places when no repetition
 
       let cycLen = cycleLen(N, D); // Cycle length
@@ -797,7 +797,7 @@
       if (d === C_ONE) {
         str+= n;
       } else {
-        let whole = n / d;
+        let whole = trunc(n / d);
         if (excludeWhole && whole > C_ZERO) {
           str+= whole;
           str+= " ";
@@ -825,7 +825,7 @@
       if (d === C_ONE) {
         str+= n;
       } else {
-        let whole = n / d;
+        let whole = trunc(n / d);
         if (excludeWhole && whole > C_ZERO) {
           str+= whole;
           n%= d;

--- a/fraction.js
+++ b/fraction.js
@@ -835,13 +835,14 @@
         return "NaN";
       }
 
-      dec = dec || 15; // 15 = decimal places when no repetation
+      dec = dec || 15; // 15 = decimal places when no repetition
 
       var cycLen = cycleLen(N, D); // Cycle length
       var cycOff = cycleStart(N, D, cycLen); // Cycle start
 
       var str = this['s'] < 0 ? "-" : "";
 
+      // Append integer part
       str+= N / D | 0;
 
       N%= D;


### PR DESCRIPTION
I now noticed it was missing in `toFraction` and `toLatex` too. I also added 1 comment to `fraction.js` that was present in `bigfraction.js`. And fixed the same "repetation" typo. And changed "js" to "typescript" in the TS example