### PR TITLE
Use Math.trunc in `toString()` instead of bitwise operator.

### DIFF
--- a/bigfraction.js
+++ b/bigfraction.js
@@ -740,7 +740,7 @@
       let D = this["d"];
 
       function trunc(x) {
-          return typeof x === 'bigint' ? x : Math.trunc(x);
+          return typeof x === 'bigint' ? x : Math.floor(x);
       }
 
       dec = dec || 15; // 15 = decimal places when no repetition

--- a/bigfraction.js
+++ b/bigfraction.js
@@ -740,7 +740,7 @@
       let D = this["d"];
 
       function trunc(x) {
-          return typeof x === 'bigint' ? x : Math.floor(x);
+          return typeof x === 'bigint' ? x : Math.trunc(x);
       }
 
       dec = dec || 15; // 15 = decimal places when no repetition

--- a/fraction.cjs
+++ b/fraction.cjs
@@ -849,9 +849,7 @@
       var N = this["n"];
       var D = this["d"];
 
-      function trunc(x) {
-        return Math.trunc(x);
-      }
+      var trunc = Math.trunc;
 
       if (isNaN(N) || isNaN(D)) {
         return "NaN";

--- a/fraction.cjs
+++ b/fraction.cjs
@@ -857,7 +857,7 @@
         return "NaN";
       }
 
-      dec = dec || 15; // 15 = decimal places when no repetation
+      dec = dec || 15; // 15 = decimal places when no repetition
 
       var cycLen = cycleLen(N, D); // Cycle length
       var cycOff = cycleStart(N, D, cycLen); // Cycle start

--- a/fraction.cjs
+++ b/fraction.cjs
@@ -849,6 +849,10 @@
       var N = this["n"];
       var D = this["d"];
 
+      function trunc(x) {
+        return Math.trunc(x);
+      }
+
       if (isNaN(N) || isNaN(D)) {
         return "NaN";
       }
@@ -860,7 +864,7 @@
 
       var str = this['s'] < 0 ? "-" : "";
 
-      str+= Math.trunc(N / D);
+      str+= trunc(N / D);
 
       N%= D;
       N*= 10;
@@ -871,20 +875,20 @@
       if (cycLen) {
 
         for (var i = cycOff; i--;) {
-          str+= Math.trunc(N / D);
+          str+= trunc(N / D);
           N%= D;
           N*= 10;
         }
         str+= "(";
         for (var i = cycLen; i--;) {
-          str+= Math.trunc(N / D);
+          str+= trunc(N / D);
           N%= D;
           N*= 10;
         }
         str+= ")";
       } else {
         for (var i = dec; N && i--;) {
-          str+= Math.trunc(N / D);
+          str+= trunc(N / D);
           N%= D;
           N*= 10;
         }

--- a/fraction.cjs
+++ b/fraction.cjs
@@ -849,8 +849,6 @@
       var N = this["n"];
       var D = this["d"];
 
-      var trunc = Math.trunc;
-
       if (isNaN(N) || isNaN(D)) {
         return "NaN";
       }
@@ -862,7 +860,7 @@
 
       var str = this['s'] < 0 ? "-" : "";
 
-      str+= trunc(N / D);
+      str+= Math.floor(N / D);
 
       N%= D;
       N*= 10;
@@ -873,20 +871,20 @@
       if (cycLen) {
 
         for (var i = cycOff; i--;) {
-          str+= trunc(N / D);
+          str+= Math.floor(N / D);
           N%= D;
           N*= 10;
         }
         str+= "(";
         for (var i = cycLen; i--;) {
-          str+= trunc(N / D);
+          str+= Math.floor(N / D);
           N%= D;
           N*= 10;
         }
         str+= ")";
       } else {
         for (var i = dec; N && i--;) {
-          str+= trunc(N / D);
+          str+= Math.floor(N / D);
           N%= D;
           N*= 10;
         }

--- a/fraction.cjs
+++ b/fraction.cjs
@@ -860,7 +860,7 @@
 
       var str = this['s'] < 0 ? "-" : "";
 
-      str+= N / D | 0;
+      str+= Math.trunc(N / D);
 
       N%= D;
       N*= 10;
@@ -871,20 +871,20 @@
       if (cycLen) {
 
         for (var i = cycOff; i--;) {
-          str+= N / D | 0;
+          str+= Math.trunc(N / D);
           N%= D;
           N*= 10;
         }
         str+= "(";
         for (var i = cycLen; i--;) {
-          str+= N / D | 0;
+          str+= Math.trunc(N / D);
           N%= D;
           N*= 10;
         }
         str+= ")";
       } else {
         for (var i = dec; N && i--;) {
-          str+= N / D | 0;
+          str+= Math.trunc(N / D);
           N%= D;
           N*= 10;
         }

--- a/fraction.js
+++ b/fraction.js
@@ -846,6 +846,10 @@ Fraction.prototype = {
     var N = this["n"];
     var D = this["d"];
 
+    function trunc(x) {
+      return Math.trunc(x);
+    }
+
     if (isNaN(N) || isNaN(D)) {
       return "NaN";
     }
@@ -857,7 +861,7 @@ Fraction.prototype = {
 
     var str = this['s'] < 0 ? "-" : "";
 
-    str+= Math.trunc(N / D);
+    str+= trunc(N / D);
 
     N%= D;
     N*= 10;
@@ -868,20 +872,20 @@ Fraction.prototype = {
     if (cycLen) {
 
       for (var i = cycOff; i--;) {
-        str+= Math.trunc(N / D);
+        str+= trunc(N / D);
         N%= D;
         N*= 10;
       }
       str+= "(";
       for (var i = cycLen; i--;) {
-        str+= Math.trunc(N / D);
+        str+= trunc(N / D);
         N%= D;
         N*= 10;
       }
       str+= ")";
     } else {
       for (var i = dec; N && i--;) {
-        str+= Math.trunc(N / D);
+        str+= trunc(N / D);
         N%= D;
         N*= 10;
       }

--- a/fraction.js
+++ b/fraction.js
@@ -846,9 +846,7 @@ Fraction.prototype = {
     var N = this["n"];
     var D = this["d"];
 
-    function trunc(x) {
-      return Math.trunc(x);
-    }
+    var trunc = Math.trunc;
 
     if (isNaN(N) || isNaN(D)) {
       return "NaN";

--- a/fraction.js
+++ b/fraction.js
@@ -850,14 +850,14 @@ Fraction.prototype = {
       return "NaN";
     }
 
-    dec = dec || 15; // 15 = decimal places when no repetation
+    dec = dec || 15; // 15 = decimal places when no repetition
 
     var cycLen = cycleLen(N, D); // Cycle length
     var cycOff = cycleStart(N, D, cycLen); // Cycle start
 
     var str = this['s'] < 0 ? "-" : "";
 
-    str+= N / D | 0;
+    str+= Math.trunc(N / D);
 
     N%= D;
     N*= 10;
@@ -868,20 +868,20 @@ Fraction.prototype = {
     if (cycLen) {
 
       for (var i = cycOff; i--;) {
-        str+= N / D | 0;
+        str+= Math.trunc(N / D);
         N%= D;
         N*= 10;
       }
       str+= "(";
       for (var i = cycLen; i--;) {
-        str+= N / D | 0;
+        str+= Math.trunc(N / D);
         N%= D;
         N*= 10;
       }
       str+= ")";
     } else {
       for (var i = dec; N && i--;) {
-        str+= N / D | 0;
+        str+= Math.trunc(N / D);
         N%= D;
         N*= 10;
       }

--- a/fraction.js
+++ b/fraction.js
@@ -846,8 +846,6 @@ Fraction.prototype = {
     var N = this["n"];
     var D = this["d"];
 
-    var trunc = Math.trunc;
-
     if (isNaN(N) || isNaN(D)) {
       return "NaN";
     }
@@ -859,7 +857,7 @@ Fraction.prototype = {
 
     var str = this['s'] < 0 ? "-" : "";
 
-    str+= trunc(N / D);
+    str+= Math.floor(N / D);
 
     N%= D;
     N*= 10;
@@ -870,20 +868,20 @@ Fraction.prototype = {
     if (cycLen) {
 
       for (var i = cycOff; i--;) {
-        str+= trunc(N / D);
+        str+= Math.floor(N / D);
         N%= D;
         N*= 10;
       }
       str+= "(";
       for (var i = cycLen; i--;) {
-        str+= trunc(N / D);
+        str+= Math.floor(N / D);
         N%= D;
         N*= 10;
       }
       str+= ")";
     } else {
       for (var i = dec; N && i--;) {
-        str+= trunc(N / D);
+        str+= Math.floor(N / D);
         N%= D;
         N*= 10;
       }

--- a/tests/fraction.test.js
+++ b/tests/fraction.test.js
@@ -42,6 +42,9 @@ var tests = [{
   set: 2.555,
   expect: "2.555"
 }, {
+  set: 1e12,
+  expect: "1000000000000"
+}, {
   set: " - ",
   expectError: InvalidParameter()
 }, {


### PR DESCRIPTION
The current implementation of `toString()` uses a bitwise operation to find the whole number part of a fraction:

```js
str+= N / D | 0;
```

This has a side-effect of converting the result to a signed 32-bit integer value, which results in numeric overflow when formatting larger values.
[More information about this here.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc#using_bitwise_no-ops_to_truncate_numbers)

Using Math's built-in truncation will allow the code to work for larger values supported by Javascript's number type.

A test was added that demonstrates this. Before this change, `(new Fraction(1e12)).toString()` returned `"-727379968"`. After this change, the same code correctly returns `"1000000000000"`.
