### PR TITLE
Add `roundTo` method to bigfraction.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 
-Tired of inprecise numbers represented by doubles, which have to store rational and irrational numbers like PI or sqrt(2) the same way? Obviously the following problem is preventable:
+Tired of imprecise numbers represented by doubles, which have to store rational and irrational numbers like PI or sqrt(2) the same way? Obviously the following problem is preventable:
 
 ```javascript
 1 / 98 * 98 // = 0.9999999999999999

--- a/bigfraction.js
+++ b/bigfraction.js
@@ -709,6 +709,33 @@
     },
 
     /**
+     * Rounds a rational number to a multiple of another rational number
+     *
+     * Ex: new Fraction('0.9').roundTo("1/8") => 7 / 8
+     **/
+    "roundTo": function(a, b) {
+
+      /*
+      k * x/y ≤ a/b < (k+1) * x/y
+      ⇔ k ≤ a/b / (x/y) < (k+1)
+      ⇔ k = floor(a/b * y/x)
+      */
+
+      parse(a, b);
+
+      const scaledN = this['n'] * P['d'];
+      const scaledD = this['d'] * P['n'];
+      let divResult = scaledN / scaledD;
+      const remainder = scaledN % scaledD;
+
+      if (remainder * 2n >= scaledD) {
+        divResult++;
+      }
+
+      return newFraction(this['s'] * divResult * P['n'], P['d']);
+    },
+
+    /**
      * Check if two rational numbers are divisible
      *
      * Ex: new Fraction(19.6).divisible(1.5);

--- a/tests/fraction.test.js
+++ b/tests/fraction.test.js
@@ -1388,6 +1388,30 @@ var tests = [{
   fn: "roundTo",
   param: "1/16",
   expect: "-0.3125"
+}, {
+  label: "1/2 round to multiple of 1/4",
+  set: 1/2,
+  fn: "roundTo",
+  param: "1/4",
+  expect: "0.5"
+}, {
+  label: "1/4 round to multiple of 1/2",
+  set: 1/4,
+  fn: "roundTo",
+  param: "1/2",
+  expect: "0.5"
+}, {
+  label: "10/3 round to multiple of 1/2",
+  set: "10/3",
+  fn: "roundTo",
+  param: "1/2",
+  expect: "3.5"
+}, {
+  label: "-10/3 round to multiple of 1/2",
+  set: "-10/3",
+  fn: "roundTo",
+  param: "1/2",
+  expect: "-3.5"
 }];
 
 describe('Fraction', function() {
@@ -1426,10 +1450,11 @@ describe('JSON', function() {
 
   it("Should be possible to stringify the object", function() {
     // TODO: BigInt is not yet serializable!!!!
-    //assert.equal('{"s":1,"n":14623,"d":330}', JSON.stringify(new Fraction("44.3(12)")));
-
-    //assert.equal('{"s":-1,"n":2,"d":1}', JSON.stringify(new Fraction(-1 / 2).inverse()));
-
+    if (typeof Fraction(1).n !== 'number') {
+      return;
+    }
+    assert.equal('{"s":1,"n":14623,"d":330}', JSON.stringify(new Fraction("44.3(12)")));
+    assert.equal('{"s":-1,"n":2,"d":1}', JSON.stringify(new Fraction(-1 / 2).inverse()));
   });
 });
 


### PR DESCRIPTION
I've implemented roundTo method for bigfraction.js using bigints. I also added some extra tests to check it works, including cases rounding up to correct for bigint division rounding down. I also re-enabled the JSON tests for the Number based fractions. Also fixed small typo in readme.